### PR TITLE
Updated the client to accept generalized Type parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.attensa</groupId>
     <artifactId>rubberband</artifactId>
-    <version>0.1.0b-SNAPSHOT</version>
+    <version>0.1.1b-SNAPSHOT</version>
 
     <name>Attensa Rubberband</name>
     <description>Attensa's Java ElasticSearch REST API client</description>
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>com.flightstats</groupId>
             <artifactId>fava</artifactId>
-            <version>0.1.12-SNAPSHOT</version>
+            <version>0.1.13</version>
         </dependency>
         <dependency>
             <groupId>com.github.rholder</groupId>

--- a/src/main/java/com/attensa/rubberband/data/ScrollContext.java
+++ b/src/main/java/com/attensa/rubberband/data/ScrollContext.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.Wither;
 
+import java.lang.reflect.Type;
+
 @Value
 @Wither
 public class ScrollContext<T> {
     String scrollId;
     String keepAliveTime;
-    Class<T> documentType;
+    Type documentType;
     @Getter(AccessLevel.NONE)
     boolean hasMore;
     long total;

--- a/src/test/java/com/attensa/rubberband/TestUtilities.java
+++ b/src/test/java/com/attensa/rubberband/TestUtilities.java
@@ -1,8 +1,8 @@
 package com.attensa.rubberband;
 
-import com.attensa.rubberband.RubberbandClient;
 import com.flightstats.http.HttpTemplate;
 import com.flightstats.http.Response;
+import com.flightstats.util.UUIDGenerator;
 import com.github.rholder.retry.Attempt;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.StopStrategies;
@@ -15,7 +15,7 @@ public class TestUtilities {
     public static RubberbandClient buildClient() {
         Gson gson = new Gson();
         Retryer<Response> retryer = new Retryer<>(StopStrategies.stopAfterAttempt(2), WaitStrategies.exponentialWait(), Attempt::hasException);
-        HttpTemplate httpTemplate = new HttpTemplate(HttpClientBuilder.create().build(), gson, retryer);
+        HttpTemplate httpTemplate = new HttpTemplate(HttpClientBuilder.create().build(), gson, retryer, new UUIDGenerator());
         return new RubberbandClient(httpTemplate, gson, "http://localhost:9200");
     }
 }

--- a/src/test/java/com/attensa/rubberband/examples/IndexAndQuery.java
+++ b/src/test/java/com/attensa/rubberband/examples/IndexAndQuery.java
@@ -1,15 +1,16 @@
 package com.attensa.rubberband.examples;
 
 import com.attensa.rubberband.Cat;
-import com.attensa.rubberband.data.ElasticSearchMappings;
-import com.flightstats.http.HttpTemplate;
-import com.flightstats.http.Response;
 import com.attensa.rubberband.RubberbandClient;
+import com.attensa.rubberband.data.ElasticSearchMappings;
 import com.attensa.rubberband.data.Page;
 import com.attensa.rubberband.data.PageRequest;
 import com.attensa.rubberband.data.SearchRequest;
 import com.attensa.rubberband.query.QueryStringQuery;
+import com.flightstats.http.HttpTemplate;
+import com.flightstats.http.Response;
 import com.flightstats.util.CollectionUtils.HashMapBuilder;
+import com.flightstats.util.UUIDGenerator;
 import com.github.rholder.retry.Attempt;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.StopStrategies;
@@ -17,9 +18,13 @@ import com.github.rholder.retry.WaitStrategies;
 import com.google.gson.Gson;
 import org.apache.http.impl.client.HttpClientBuilder;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import static com.attensa.rubberband.data.ElasticSearchMappings.*;
+import static com.attensa.rubberband.data.ElasticSearchMappings.Config;
+import static com.attensa.rubberband.data.ElasticSearchMappings.PropertyContainer;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.jooq.lambda.Seq.seq;
 
@@ -28,7 +33,7 @@ public class IndexAndQuery {
     public static void main(String[] args) throws InterruptedException {
         Gson gson = new Gson();
         Retryer<Response> retryer = new Retryer<>(StopStrategies.stopAfterAttempt(2), WaitStrategies.exponentialWait(), Attempt::hasException);
-        HttpTemplate httpTemplate = new HttpTemplate(HttpClientBuilder.create().build(), gson, retryer);
+        HttpTemplate httpTemplate = new HttpTemplate(HttpClientBuilder.create().build(), gson, retryer, new UUIDGenerator());
         RubberbandClient client = new RubberbandClient(httpTemplate, gson, "http://localhost:9200");
 
         Cat winston = new Cat("1", "Winston", "male", "Turkish Van", "A very fluffy, friendly cat.");

--- a/src/test/java/com/attensa/rubberband/examples/ScanAndScrollExample.java
+++ b/src/test/java/com/attensa/rubberband/examples/ScanAndScrollExample.java
@@ -8,6 +8,7 @@ import com.attensa.rubberband.data.SearchRequest;
 import com.attensa.rubberband.query.MatchAllQuery;
 import com.flightstats.http.HttpTemplate;
 import com.flightstats.http.Response;
+import com.flightstats.util.UUIDGenerator;
 import com.github.rholder.retry.Attempt;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.StopStrategies;
@@ -22,7 +23,7 @@ public class ScanAndScrollExample {
     public static void main(String[] args) {
         Gson gson = new Gson();
         Retryer<Response> retryer = new Retryer<>(StopStrategies.stopAfterAttempt(2), WaitStrategies.exponentialWait(), Attempt::hasException);
-        HttpTemplate httpTemplate = new HttpTemplate(HttpClientBuilder.create().build(), gson, retryer);
+        HttpTemplate httpTemplate = new HttpTemplate(HttpClientBuilder.create().build(), gson, retryer, new UUIDGenerator());
         RubberbandClient client = new RubberbandClient(httpTemplate, gson, "http://localhost:9200");
 
         long totalSeen = 0;

--- a/src/test/java/com/attensa/rubberband/examples/ScrollExample.java
+++ b/src/test/java/com/attensa/rubberband/examples/ScrollExample.java
@@ -8,6 +8,7 @@ import com.attensa.rubberband.data.SearchRequest;
 import com.attensa.rubberband.query.MatchAllQuery;
 import com.flightstats.http.HttpTemplate;
 import com.flightstats.http.Response;
+import com.flightstats.util.UUIDGenerator;
 import com.github.rholder.retry.Attempt;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.StopStrategies;
@@ -22,7 +23,7 @@ public class ScrollExample {
     public static void main(String[] args) {
         Gson gson = new Gson();
         Retryer<Response> retryer = new Retryer<>(StopStrategies.stopAfterAttempt(2), WaitStrategies.exponentialWait(), Attempt::hasException);
-        HttpTemplate httpTemplate = new HttpTemplate(HttpClientBuilder.create().build(), gson, retryer);
+        HttpTemplate httpTemplate = new HttpTemplate(HttpClientBuilder.create().build(), gson, retryer, new UUIDGenerator());
         RubberbandClient client = new RubberbandClient(httpTemplate, gson, "http://localhost:9200");
 
         long totalSeen = 0;

--- a/src/test/java/com/attensa/rubberband/tests/GeneralizedTypesTest.java
+++ b/src/test/java/com/attensa/rubberband/tests/GeneralizedTypesTest.java
@@ -1,0 +1,36 @@
+package com.attensa.rubberband.tests;
+
+import com.attensa.rubberband.Cat;
+import com.attensa.rubberband.RubberbandClient;
+import com.attensa.rubberband.TestUtilities;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.inject.util.Types.newParameterizedType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GeneralizedTypesTest {
+
+    private RubberbandClient client;
+
+    @Before
+    public void setup() {
+        client = TestUtilities.buildClient();
+    }
+
+    @Test
+    public void testGetMap() throws Exception {
+        Cat simon = new Cat(null, "Simon", "mail", "unknown", "Well loved and now deceased.");
+        String id = client.create("animals", "cat", simon);
+
+        Type type = newParameterizedType(Map.class, String.class, Object.class);
+        Optional<Map<String, Object>> retrieved = client.get("animals", "cat", id, type);
+        assertTrue(retrieved.isPresent());
+        assertEquals("unknown", retrieved.get().get("breed"));
+    }
+}

--- a/src/test/java/com/attensa/rubberband/tests/UpdateTest.java
+++ b/src/test/java/com/attensa/rubberband/tests/UpdateTest.java
@@ -1,9 +1,9 @@
 package com.attensa.rubberband.tests;
 
-import com.attensa.rubberband.RubberbandClient;
-import com.attensa.rubberband.data.DocumentUpdate;
 import com.attensa.rubberband.Cat;
+import com.attensa.rubberband.RubberbandClient;
 import com.attensa.rubberband.TestUtilities;
+import com.attensa.rubberband.data.DocumentUpdate;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +26,8 @@ public class UpdateTest {
 
         client.update("animals", "cat", new DocumentUpdate(tigger.getId(), singletonMap("description", "Feral cat who got left behind.")));
 
-        Cat updated = client.get("animals", "cat", tigger.getId(), Cat.class).orElseThrow(() -> new RuntimeException("Failed to retrieve Tigger"));
+        Cat updated = client.<Cat>get("animals", "cat", tigger.getId(), Cat.class)
+                .orElseThrow(() -> new RuntimeException("Failed to retrieve Tigger"));
 
         assertEquals("Feral cat who got left behind.", updated.getDescription());
     }


### PR DESCRIPTION
Very useful if you want to just have bare `Map<String, Object>` returned from queries, rather than having to create a class specific to the returned types.
