### PR TITLE
changed MoreLikeThis to use an ids list rather than a Document list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.attensa</groupId>
     <artifactId>rubberband</artifactId>
-    <version>0.2.0b-SNAPSHOT</version>
+    <version>0.3.0b-SNAPSHOT</version>
 
     <name>Attensa Rubberband</name>
     <description>Attensa's Java ElasticSearch REST API client</description>

--- a/src/main/java/com/attensa/rubberband/query/MoreLikeThisQuery.java
+++ b/src/main/java/com/attensa/rubberband/query/MoreLikeThisQuery.java
@@ -8,22 +8,16 @@ import java.util.List;
 public class MoreLikeThisQuery implements QueryType {
     MoreLikeThis more_like_this;
 
-    public MoreLikeThisQuery(String[] fields, List<Document> documents, String likeText, int minimumTermFrequency) {
-        this.more_like_this = new MoreLikeThis(fields, documents, likeText, minimumTermFrequency);
+    public MoreLikeThisQuery(String[] fields, List<String> ids, String likeText, int minimumTermFrequency) {
+        this.more_like_this = new MoreLikeThis(fields, ids, likeText, minimumTermFrequency);
     }
 
     @Value
     public static class MoreLikeThis {
         String[] fields;
-        List<Document> docs;
+        List<String> ids;
         String like_text;
         int min_term_freq;
     }
 
-    @Value
-    public static class Document {
-        String _index;
-        String _type;
-        String _id;
-    }
 }


### PR DESCRIPTION
The Document list no longer works with Elasticsearch 1.7.x.